### PR TITLE
Custom CMake variables

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
     )
     string(
       name: 'XMOSDOC_VERSION',
-      defaultValue: 'v4.0.0',
+      defaultValue: 'v4.0.5',
       description: 'The xmosdoc version'
     )
   }

--- a/doc/api_reference/variables.rst
+++ b/doc/api_reference/variables.rst
@@ -317,3 +317,17 @@ The same as the :ref:`optional-module-variables`, and also:
 
     set(LIB_ARCH xs2a)
     set(LIB_ARCH xs2a xs3a)
+
+Output Variables
+^^^^^^^^^^^^^^^^
+
+Experienced CMake users are able to add custom CMake code around the XCommon CMake build system. To
+support this, some variables are exposed from the ``XMOS_REGISTER_APP`` function.
+
+``APP_BUILD_TARGETS``
+  List of the target names for the applications which have been configured. This allows relationships to
+  be defined with custom CMake targets that a user may create.
+
+``APP_BUILD_ARCH``
+  String of the architecture of the application being built. This variable allows the CMake code for a
+  module to be conditionally configured based on the target architecture.

--- a/tests/hello/app_hello/CMakeLists.txt
+++ b/tests/hello/app_hello/CMakeLists.txt
@@ -3,6 +3,5 @@ include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
 project(hello)
 
 set(APP_HW_TARGET XCORE-AI-EXPLORER)
-set(APP_XC_SRCS src/hello.xc)
 
 XMOS_REGISTER_APP()

--- a/xcommon.cmake
+++ b/xcommon.cmake
@@ -440,6 +440,7 @@ function(XMOS_REGISTER_APP)
         set(APP_BUILD_ARCH "${CMAKE_HOST_SYSTEM_PROCESSOR}")
     endif()
     message(VERBOSE "Building for architecture: ${APP_BUILD_ARCH}")
+    set(APP_BUILD_ARCH ${APP_BUILD_ARCH} PARENT_SCOPE)
 
     # Find all build configs
     GET_ALL_VARS_STARTING_WITH("APP_COMPILER_FLAGS_" APP_COMPILER_FLAGS_VARS)
@@ -488,6 +489,7 @@ function(XMOS_REGISTER_APP)
             list(APPEND BUILD_TARGETS ${PROJECT_NAME}_${APP_CONFIG})
         endif()
     endforeach()
+    set(APP_BUILD_TARGETS ${BUILD_TARGETS} PARENT_SCOPE)
 
     if(${CONFIGS_COUNT} EQUAL 0)
         # Only print the default-only config at the verbose log level
@@ -753,6 +755,7 @@ function(XMOS_STATIC_LIBRARY)
         set_property(TARGET ${LIB_NAME}-${lib_arch} PROPERTY ARCHIVE_OUTPUT_NAME ${LIB_NAME})
         list(APPEND BUILD_TARGETS ${LIB_NAME}-${lib_arch})
     endforeach()
+    set(APP_BUILD_TARGETS ${BUILD_TARGETS} PARENT_SCOPE)
 
     if(DEFINED XMOS_DEPS_ROOT_DIR)
         message(WARNING "XMOS_DEPS_ROOT_DIR is deprecated; please use XMOS_SANDBOX_DIR instead")


### PR DESCRIPTION
Added a couple of variables from XMOS_REGISTER_APP being set in the parent scope so that they can be used by other CMake code in the application CMakeLists.txt.

Also a couple of minor changes:
- cleanup unnecessary variable in hello testcase
- update xmosdoc version to fix incorrect heading font sizes in PDF

Fixes #59.