### PR TITLE
Generated source file

### DIFF
--- a/tests/generated_source_file/README.txt
+++ b/tests/generated_source_file/README.txt
@@ -1,0 +1,1 @@
+Application requires source file foo.c which is generated in the build directory by a cmake echo command.

--- a/tests/generated_source_file/app_generated_source_file/CMakeLists.txt
+++ b/tests/generated_source_file/app_generated_source_file/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.21)
+include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
+project(generated_source_file)
+
+set(APP_HW_TARGET XCORE-AI-EXPLORER)
+
+XMOS_REGISTER_APP()
+
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/generated)
+add_custom_target(foo.c
+                  ${CMAKE_COMMAND} -E echo \"void foo() {}\" > ${CMAKE_BINARY_DIR}/generated/foo.c
+                  BYPRODUCTS ${CMAKE_BINARY_DIR}/generated/foo.c
+                  )
+target_sources(generated_source_file PRIVATE ${CMAKE_BINARY_DIR}/generated/foo.c)

--- a/tests/generated_source_file/app_generated_source_file/src/main.c
+++ b/tests/generated_source_file/app_generated_source_file/src/main.c
@@ -1,0 +1,6 @@
+void foo();
+
+int main() {
+    foo();
+    return 0;
+}


### PR DESCRIPTION
Added a test case which serves as a simple example of how to write extra cmake code in the application CMakeLists.txt file to generate a source file and add it to the binary target. No changes were needed in xcommon.cmake to support this behaviour.