### PR TITLE
Add warning if LIB_NAME doesn't match expected module name

### DIFF
--- a/xcommon.cmake
+++ b/xcommon.cmake
@@ -614,10 +614,14 @@ function(XMOS_REGISTER_MODULE)
                 message(WARNING "Expected major version ${DEP_MAJOR_VER} for ${LIB_NAME} but got ${CMAKE_MATCH_1}")
             endif()
         else()
-            message(ERROR "Invalid LIB_VERSION ${LIB_VERSION} for ${LIB_NAME}")
+            message(WARNING "Invalid LIB_VERSION ${LIB_VERSION} for ${LIB_NAME}")
         endif()
     endif()
 
+    # DEP_NAME was set in XMOS_REGISTER_DEPS as the expected name of the module
+    if(NOT LIB_NAME STREQUAL DEP_NAME)
+        message(WARNING "Module ${DEP_NAME} has mismatched LIB_NAME: ${LIB_NAME}")
+    endif()
     set(current_module ${LIB_NAME})
     XMOS_REGISTER_DEPS()
 


### PR DESCRIPTION
Fixes #19.

The code had changed a lot since issue #19 was raised, so the ugly error it mentions didn't really exist any more, but the warning added here is useful to catch the (non-fatal) error of setting LIB_NAME incorrectly.

Also, there is no message level called `ERROR`, so changed the one above to a warning as well.