### PR TITLE
Store PCA file list in unique filename for multi-app repositories

### DIFF
--- a/xcommon.cmake
+++ b/xcommon.cmake
@@ -584,7 +584,7 @@ function(XMOS_REGISTER_APP)
             list(TRANSFORM BUILD_ADDED_DEPS_PATHS PREPEND ${XMOS_SANDBOX_DIR}/)
 
             string(REPLACE ";" "\" \"" PCA_FILES_PATH_STR "${PCA_FILES_PATH}")
-            set(PCA_FILES_RESP ${CMAKE_BINARY_DIR}/_pca${DOT_BUILD_SUFFIX}.rsp)
+            set(PCA_FILES_RESP ${CMAKE_BINARY_DIR}/${target}/_pca.rsp)
             file(WRITE ${PCA_FILES_RESP} "\"${PCA_FILES_PATH_STR}\"")
 
             set(PCA_FILE ${DOT_BUILD_DIR}/pca.xml)


### PR DESCRIPTION
Fixes #135

The `${target}` variable contains the application name and config name, so this will be a unique folder in which to store the PCA response file.

Tested by successfully building sw_usb_audio, which was previously failing.