### PR TITLE
minor change to manifest column heading to remove whitespace

### DIFF
--- a/doc/dependency_management.rst
+++ b/doc/dependency_management.rst
@@ -55,7 +55,7 @@ The columns in the manifest file are:
 - Branch/tag: the currently checked out branch or tag. A tag takes precedence, so if the head of a branch is explicitly
   checked out, but that changeset has also been tagged, then the tag will be reported here.
 - Changeset: the git commit hash identifying the current changeset checked out in the repository
-- Dependency Requirement: (hidden) the requirement for the repository from the dependent modules list variable. This can
+- Dependency_Requirement: (hidden) the requirement for the repository from the dependent modules list variable. This can
   differ from the current changeset if the developer has manually checked out a different version of that component. This
   column is only displayed if ``cmake`` is run with the option ``-D FULL_MANIFEST=TRUE``.
 

--- a/xcommon.cmake
+++ b/xcommon.cmake
@@ -32,7 +32,7 @@ set_property(GLOBAL PROPERTY SSH_HOST_FAILURE "")
 
 set(MANIFEST_OUT ${CMAKE_BINARY_DIR}/manifest.txt)
 if(FULL_MANIFEST)
-    set(DEP_REQ_HEADER "                                  | Dependency requirement")
+    set(DEP_REQ_HEADER "                                  | Dependency_requirement")
     set(DEP_REQ_DIVIDER "+-----------------------------------------")
 endif()
 set(MANIFEST_HEADER


### PR DESCRIPTION
I've been using fairly simple parsing of the manifest columns by splitting the lines based on white space and `|` I can write a more complex parser but this seemed like a quicker solution.