### PR TITLE
Only perform PCA on XC sources

### DIFF
--- a/tests/pca_libs/app_pca_libs/src/cxx_pca.cpp
+++ b/tests/pca_libs/app_pca_libs/src/cxx_pca.cpp
@@ -1,0 +1,9 @@
+extern "C" {
+    void fn_cxx()
+    {
+        // C++ flags are not passed to PCA command, so use nullptr from C++11 to
+        // force a failure if PCA is performed on this C++ source file
+        auto var0 = nullptr;
+        (void) var0;
+    }
+}

--- a/tests/pca_libs/app_pca_libs/src/pca_libs.xc
+++ b/tests/pca_libs/app_pca_libs/src/pca_libs.xc
@@ -3,6 +3,8 @@
 #include "mod0.h"
 #include "mod1.h"
 
+void fn_cxx();
+
 int add_1(int a)
 {
     return a + 1;
@@ -18,6 +20,8 @@ int main()
     printintln(x);
     printintln(y);
     printintln(z);
+
+    fn_cxx();
 
     return 0;
 }

--- a/xcommon.cmake
+++ b/xcommon.cmake
@@ -586,6 +586,9 @@ function(XMOS_REGISTER_APP)
 
             get_target_property(target_srcs ${target} SOURCES)
 
+            # Filter sources so that the only sources are XC
+            list(FILTER target_srcs INCLUDE REGEX "\\.xc$")
+
             get_target_property(target_link_libs ${target} LINK_LIBRARIES)
             list(FILTER target_link_libs EXCLUDE REGEX "^.+-NOTFOUND$")
             set(static_incdirs "")


### PR DESCRIPTION
Fixes #72

I checked the XCommon behaviour with different sources: C, C++ and ASM sources are all passed through PCA, but no specialisation occurs. So to reduce the time spent on PCA, I have filtered out all sources except XC files; also extended one of the test cases to fail if PCA is attempted on C++ sources.