### PR TITLE
Rebuild object files when XN file is modified

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ UNRELEASED
   * FIXED: xpca response file erroneously deleted
   * FIXED: PCA commands fail if there are spaces in the directory path
   * FIXED: PCA failures when building C++ sources
+  * FIXED: modifying XN file doesn't cause an application rebuild
 
 0.2.0
 -----


### PR DESCRIPTION
Fixes #118

Tested both with and without PCA, with and without application configs. In all cases, modifying the XN file now causes all PCA files to be re-generated if PCA is enabled, and then all source files to be recompiled.