### PR TITLE
Static library support

### DIFF
--- a/doc/examples/static_library.rst
+++ b/doc/examples/static_library.rst
@@ -13,14 +13,19 @@ Directory structure
            |-- lib_mod0/
            |           |-- lib_mod0/
            |                       |-- api/
+           |                       |      |-- mod0.h
            |                       |-- lib_build_info.cmake
            |                       |-- src/
+           |                              |-- mod0.c
+           |
            |-- lib_abc/
                       |-- CMakeLists.txt
                       |-- lib_abc/
                                  |-- api/
+                                 |      |-- abc.h
                                  |-- CMakeLists.txt
                                  |-- libsrc/
+                                           |-- abc.c
 
 CMake file contents
 """""""""""""""""""
@@ -33,6 +38,8 @@ CMake file contents
     include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
     project(lib_abc)
 
+    set(XMOS_SANDBOX_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
+
     add_subdirectory(lib_abc)
 
 `sandbox/lib_abc/lib_abc/CMakeLists.txt`
@@ -43,7 +50,8 @@ CMake file contents
     set(LIB_VERSION 1.2.3)
     set(LIB_ARCH xs2a xs3a)
     set(LIB_INCLUDES api)
-    set(LIB_DEPENDENT_MODULES "lib_mod0(3.2.0)")
+    set(LIB_C_SRCS libsrc/abc.c)
+    set(LIB_DEPENDENT_MODULES "lib_mod0(1.0.0)")
 
     XMOS_STATIC_LIBRARY()
 
@@ -72,5 +80,5 @@ Commands to build the static libraries, from working directory ``sandbox/lib_abc
 A static library archive is created for each architecture, with a cmake include file
 so that it can be added to an application project and linked into an executable.
 
-- ``sandbox/lib_abc/lib_abc/lib/xs2a/liblib_abc.a`` included via ``sandbox/lib_abc/lib_abc/lib/lib_abc-xs2a.cmake``
-- ``sandbox/lib_abc/lib_abc/lib/xs3a/liblib_abc.a`` included via ``sandbox/lib_abc/lib_abc/lib/lib_abc-xs3a.cmake``
+- ``sandbox/lib_abc/lib_abc/lib/xs2a/lib_abc.a`` included via ``sandbox/lib_abc/lib_abc/lib/lib_abc-xs2a.cmake``
+- ``sandbox/lib_abc/lib_abc/lib/xs3a/lib_abc.a`` included via ``sandbox/lib_abc/lib_abc/lib/lib_abc-xs3a.cmake``

--- a/tests/_fetch_deps/app_fetch_deps/CMakeLists.txt
+++ b/tests/_fetch_deps/app_fetch_deps/CMakeLists.txt
@@ -3,7 +3,8 @@ include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
 project(fetch_deps)
 
 set(APP_HW_TARGET XCORE-AI-EXPLORER)
-set(APP_DEPENDENT_MODULES "lib_dsp(6.3.0)")
+set(APP_DEPENDENT_MODULES "lib_dsp(6.3.0)"
+                          "lib_test_staticlib(1.0.0)")
 
 set(XMOS_SANDBOX_DIR ${CMAKE_SOURCE_DIR}/..)
 

--- a/tests/_fetch_deps/app_fetch_deps/src/main.xc
+++ b/tests/_fetch_deps/app_fetch_deps/src/main.xc
@@ -1,5 +1,6 @@
 #include <print.h>
 #include "dsp.h"
+#include "test_staticlib.h"
 
 int main() {
     dsp_complex_t a = {1, 2};
@@ -7,5 +8,8 @@ int main() {
     dsp_complex_t sum = dsp_complex_add(a, b);
     printintln(sum.re);
     printintln(sum.im);
+
+    test_staticlib();
+
     return 0;
 }

--- a/tests/test_cmake.py
+++ b/tests/test_cmake.py
@@ -135,7 +135,7 @@ def rmtree_error(func, path, exc_info):
 # parameterisation of test_cmake.
 def test_fetch_deps(cmake):
     test_dir = Path(__file__).parent / "_fetch_deps"
-    dep_dirs = ["lib_dsp", "lib_logging"]
+    dep_dirs = ["lib_dsp", "lib_logging", "lib_test_staticlib"]
 
     for dir in [test_dir / d for d in dep_dirs]:
         if dir.exists() and dir.is_dir():

--- a/xcommon.cmake
+++ b/xcommon.cmake
@@ -740,9 +740,21 @@ function(XMOS_REGISTER_DEPS)
             endif()
             cmake_path(SET dep_dir NORMALIZE ${dep_dir})
 
+            # Fetch dependency if not present
+            if(NOT IS_DIRECTORY ${dep_dir})
+                message(STATUS "Fetching ${DEP_NAME}: ${DEP_VERSION} from ${DEP_REPO} into ${dep_dir}")
+                FetchContent_Declare(
+                    ${DEP_NAME}
+                    GIT_REPOSITORY ${DEP_REPO}
+                    GIT_TAG ${DEP_VERSION}
+                    SOURCE_DIR ${dep_dir}
+                )
+                FetchContent_Populate(${DEP_NAME})
+            endif()
+
             # Add dependencies directories
             if(IS_DIRECTORY ${dep_dir}/${DEP_NAME}/lib)
-                message(VERBOSE "Adding static library ${DEP_NAME}-${APP_BUILD_ARCH}")
+                message(STATUS "Adding static library ${DEP_NAME}-${APP_BUILD_ARCH}")
                 include(${dep_dir}/${DEP_NAME}/lib/${DEP_NAME}-${APP_BUILD_ARCH}.cmake)
                 get_target_property(DEP_VERSION ${DEP_NAME} VERSION)
                 foreach(target ${APP_BUILD_TARGETS})
@@ -753,17 +765,6 @@ function(XMOS_REGISTER_DEPS)
                 # Clear source variables to avoid inheriting from parent scope
                 # Either lib_build_info.cmake will populate these, otherwise we glob for them
                 unset_lib_vars()
-
-                if(NOT EXISTS ${dep_dir})
-                    message(STATUS "Fetching ${DEP_NAME}: ${DEP_VERSION} from ${DEP_REPO} into ${dep_dir}")
-                    FetchContent_Declare(
-                        ${DEP_NAME}
-                        GIT_REPOSITORY ${DEP_REPO}
-                        GIT_TAG ${DEP_VERSION}
-                        SOURCE_DIR ${dep_dir}
-                    )
-                    FetchContent_Populate(${DEP_NAME})
-                endif()
 
                 set(module_dir ${dep_dir}/${DEP_NAME})
                 message(STATUS "Adding module ${DEP_NAME}")


### PR DESCRIPTION
Fixes #78

- created github.com/xmos/lib_test_staticlib as an example static library repository
- extended the dependency fetching testcase to fetch lib_test_staticlib and link it into an application
- added support in XCommon CMake for fetching a repository with a static library into the sandbox
- removed the "liblib" naming on archives: if the library LIB_NAME begins with "lib" (as is expected) then the CMake library prefix is cleared; otherwise the "lib" prefix will still be added (eg. wrapping a third-party static library which doesn't follow our naming convention)
- updated documentation