### PR TITLE
Always test XCommon CMake from within the repository

### DIFF
--- a/tests/test_cmake.py
+++ b/tests/test_cmake.py
@@ -41,10 +41,8 @@ def cleanup_app(app_dir):
 
 
 def build(dir, cmake):
-    # Set XMOS_CMAKE_PATH in local environment if not set
     cmake_env = os.environ
-    if "XMOS_CMAKE_PATH" not in cmake_env:
-        cmake_env["XMOS_CMAKE_PATH"] = str(Path(__file__).parents[1])
+    cmake_env["XMOS_CMAKE_PATH"] = str(Path(__file__).parents[1])
 
     ret = subprocess.run(
         [cmake, "-G", "Unix Makefiles", "-B", "build"],
@@ -160,8 +158,7 @@ def test_native_build(cmake):
     cleanup_static_lib(lib_dir)
 
     cmake_env = os.environ
-    if "XMOS_CMAKE_PATH" not in cmake_env:
-        cmake_env["XMOS_CMAKE_PATH"] = str(Path(__file__).parents[1])
+    cmake_env["XMOS_CMAKE_PATH"] = str(Path(__file__).parents[1])
 
     cmake_native_cmd = [
         cmake,

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -22,8 +22,7 @@ def test_unit(cmake, unit):
         shutil.rmtree(build_dir)
 
     cmake_env = os.environ
-    if "XMOS_CMAKE_PATH" not in cmake_env:
-        cmake_env["XMOS_CMAKE_PATH"] = str(Path(__file__).parents[1])
+    cmake_env["XMOS_CMAKE_PATH"] = str(Path(__file__).parents[1])
     ret = subprocess.run(
         [cmake, "-G", "Unix Makefiles", "-B", "build"], cwd=test_dir, env=cmake_env
     )


### PR DESCRIPTION
Since I've been using engineering releases of XTC 15.3 with XCommon CMake built in, I've hit situations where I run the tests locally and it doesn't use my local changes in xcommon_cmake because the XMOS_CMAKE_PATH variable is already set to point to the tools installation. I don't think there is a need to be able to override this and we should always test using the local xcommon_cmake codebase.