### PR TITLE
Add XCOMMON_CMAKE_VER cache variable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ XCommon CMake Change Log
 UNRELEASED
 ----------
 
+  * ADDED:   XCOMMON_CMAKE_VER cache variable
   * FIXED:   Use CONFIGURE_DEPENDS option in all GLOBs to ensure build is always correct
 
 1.1.0

--- a/doc/api_reference/variables.rst
+++ b/doc/api_reference/variables.rst
@@ -369,10 +369,26 @@ Output Variables
 Experienced CMake users are able to add custom CMake code around the XCommon CMake build system. To
 support this, some variables are exposed from the ``XMOS_REGISTER_APP`` function.
 
+``APP_BUILD_ARCH``
+  String of the architecture of the application being built. This variable allows the CMake code for a
+  module to be conditionally configured based on the target architecture.
+
 ``APP_BUILD_TARGETS``
   List of the target names for the applications which have been configured. This allows relationships to
   be defined with custom CMake targets that a user may create.
 
-``APP_BUILD_ARCH``
-  String of the architecture of the application being built. This variable allows the CMake code for a
-  module to be conditionally configured based on the target architecture.
+``XCOMMON_CMAKE_VER``
+  String containing the version number of XCommon CMake. This is printed as part of a version string
+  message when run with ``--log-level=VERBOSE`` at the beginning of the CMake configuration stage.
+  This can be used to write CMake code using knowledge of which versions of XCommon CMake include the
+  required features. Version number comparisons must be performed with the ``VERSION_`` binary tests
+  in the ``if`` function for the correct interpretation of the version number sub-components. For
+  example, if a feature is added in v1.1.0:
+
+  .. code-block:: cmake
+
+  if(XCOMMON_CMAKE_VER VERSION_GREATER_EQUAL 1.1.0)
+      # Use the supported feature
+  else()
+      # Do something else as feature is not supported
+  endif()

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,3 @@
 pytest
 pytest-xdist
+pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ pytest==7.4.2
     #   pytest-xdist
 pytest-xdist==3.3.1
     # via -r requirements.in
+pyyaml==6.0.1
+    # via -r requirements.in

--- a/tests/_version_match/app_version_match/CMakeLists.txt
+++ b/tests/_version_match/app_version_match/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.21)
+include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
+project(version_match)
+
+set(APP_HW_TARGET XCORE-AI-EXPLORER)
+
+XMOS_REGISTER_APP()

--- a/tests/_version_match/app_version_match/src/main.c
+++ b/tests/_version_match/app_version_match/src/main.c
@@ -1,0 +1,4 @@
+int main()
+{
+    return 0;
+}

--- a/tests/test_version_match.py
+++ b/tests/test_version_match.py
@@ -1,0 +1,58 @@
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+import yaml
+
+
+def cleanup_app(app_dir):
+    dot_build_dirs = [
+        d.name for d in app_dir.iterdir() if d.is_dir() and d.name.startswith(".build")
+    ]
+    for d in ["build", "bin", *dot_build_dirs]:
+        dir = app_dir / d
+        if dir.exists() and dir.is_dir():
+            shutil.rmtree(dir)
+
+
+def cmake_verbose(dir, cmake):
+    cmake_env = os.environ
+    cmake_env["XMOS_CMAKE_PATH"] = str(Path(__file__).parents[1])
+
+    ret = subprocess.run(
+        [cmake, "-G", "Unix Makefiles", "-B", "build", "--log-level=VERBOSE"],
+        cwd=dir,
+        env=cmake_env,
+        text=True,
+        capture_output=True,
+    )
+    assert ret.returncode == 0
+
+    return ret.stdout
+
+
+# Perform CMake configuration on a dummy application with verbose logging to get the
+# current version number, and then compare this with the version number in settings.yml
+def test_version_match(cmake):
+    app_dir = Path(__file__).parent / "_version_match" / "app_version_match"
+
+    cleanup_app(app_dir)
+    output = cmake_verbose(app_dir, cmake)
+
+    version_re = r"^-- XCommon CMake version v([0-9]+\.[0-9]+\.[0-9]+)$"
+    match = re.search(version_re, output, flags=re.MULTILINE | re.DOTALL)
+    assert match
+    xcommon_cmake_ver = match.group(1)
+
+    settings_yml_file = Path(__file__).parents[1] / "settings.yml"
+    with open(settings_yml_file, "r") as f:
+        settings_yml = yaml.safe_load(f)
+
+    settings_ver = settings_yml["version"]
+
+    assert xcommon_cmake_ver == settings_ver
+
+    # Cleanup
+    cleanup_app(app_dir)

--- a/xcommon.cmake
+++ b/xcommon.cmake
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 3.21)
 
 include_guard(GLOBAL)
 
+set(XCOMMON_CMAKE_VER 1.1.0 CACHE INTERNAL "Version of XCommon CMake")
+
+macro(print_xcommon_cmake_version)
+    message(VERBOSE "XCommon CMake version v${XCOMMON_CMAKE_VER}")
+endmacro()
+
 option(BUILD_NATIVE "Build applications/libraries for the native CPU instead of the xcore architecture")
 
 # Set up compiler
@@ -441,6 +447,7 @@ endmacro()
 
 ## Registers an application and its dependencies
 function(XMOS_REGISTER_APP)
+    print_xcommon_cmake_version()
     message(STATUS "Configuring application: ${PROJECT_NAME}")
 
     if(NOT BUILD_NATIVE AND NOT APP_HW_TARGET)
@@ -796,6 +803,7 @@ endfunction()
 
 ## Registers a static library target
 function(XMOS_STATIC_LIBRARY)
+    print_xcommon_cmake_version()
     message(STATUS "Configuring static library: ${LIB_NAME}")
 
     if(NOT BUILD_NATIVE)


### PR DESCRIPTION
Added XCOMMON_CMAKE_VER variable, printed at the beginning of CMake configuration when using verbose logging, with a testcase to make sure it matches the version in settings.yml.