### PR TITLE
Add Ninja to regression tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 @Library('xmos_jenkins_shared_library@v0.27.0') _
 
-def run_tests(cmake_ver) {
+def run_tests(cmake_ver, generator) {
   createVenv('python_version.txt')
   withVenv {
     sh 'pip install -r requirements.txt'
@@ -16,7 +16,7 @@ def run_tests(cmake_ver) {
     dir('tests') {
       withTools(params.TOOLS_VERSION) {
         withEnv(["XMOS_CMAKE_PATH=${WORKSPACE}"]) {
-          sh 'pytest -n auto --junitxml=pytest_result.xml'
+          sh "pytest -n auto --junitxml=pytest_result.xml -k ${generator}"
         }
       }
     }
@@ -70,6 +70,10 @@ pipeline {
             name 'CMAKE_VERSION'
             values '3.21.0', 'latest'
           }
+          axis {
+            name 'GENERATOR'
+            values 'generator0', 'generator1'
+          }
         }
         stages {
           stage("Test") {
@@ -78,7 +82,7 @@ pipeline {
             }
             steps {
               println "Stage running on ${env.NODE_NAME}"
-              run_tests("${CMAKE_VERSION}")
+              run_tests("${CMAKE_VERSION}", "${GENERATOR}")
             }
             post {
               always {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,16 @@ import platform
 
 import pytest
 
+from typing import NamedTuple
+
+class Generator(NamedTuple):
+    label: str
+    program: str
+
+@pytest.fixture(params=[Generator('Unix Makefiles', "xmake"), Generator('Ninja', "ninja")])
+def generator(request):
+    return request.param
+
 
 # If a virtual environment is active and contains cmake, use that one,
 # otherwise just run "cmake" and expect it to be on the search path.

--- a/tests/lib_generated_source_file/lib_mod0/lib_mod0/lib_build_info.cmake
+++ b/tests/lib_generated_source_file/lib_mod0/lib_mod0/lib_build_info.cmake
@@ -5,9 +5,8 @@ set(LIB_DEPENDENT_MODULES "")
 
 XMOS_REGISTER_MODULE()
 
-add_custom_target(mod0_generated.c
-                  ${CMAKE_COMMAND} -E echo \"void mod0_generated() {}\" > ${CMAKE_BINARY_DIR}/mod0_generated.c
-                  BYPRODUCTS ${CMAKE_BINARY_DIR}/mod0_generated.c
+add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/mod0_generated.c
+                   COMMAND ${CMAKE_COMMAND} -E echo \"void mod0_generated() {}\" > ${CMAKE_BINARY_DIR}/mod0_generated.c
                  )
 
 foreach(_target ${APP_BUILD_TARGETS})

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -13,7 +13,7 @@ def list_units():
 
 
 @pytest.mark.parametrize("unit", list_units())
-def test_unit(cmake, unit):
+def test_unit(cmake, generator, unit):
     test_dir = Path(__file__).parent / unit
     build_dir = test_dir / "build"
 
@@ -24,7 +24,7 @@ def test_unit(cmake, unit):
     cmake_env = os.environ
     cmake_env["XMOS_CMAKE_PATH"] = str(Path(__file__).parents[1])
     ret = subprocess.run(
-        [cmake, "-G", "Unix Makefiles", "-B", "build"], cwd=test_dir, env=cmake_env
+        [cmake, "-G", generator.label, "-B", "build"], cwd=test_dir, env=cmake_env
     )
     assert ret.returncode == 0
 

--- a/tests/test_version_match.py
+++ b/tests/test_version_match.py
@@ -17,12 +17,12 @@ def cleanup_app(app_dir):
             shutil.rmtree(dir)
 
 
-def cmake_verbose(dir, cmake):
+def cmake_verbose(dir, cmake, generator):
     cmake_env = os.environ
     cmake_env["XMOS_CMAKE_PATH"] = str(Path(__file__).parents[1])
 
     ret = subprocess.run(
-        [cmake, "-G", "Unix Makefiles", "-B", "build", "--log-level=VERBOSE"],
+        [cmake, "-G", generator.label, "-B", "build", "--log-level=VERBOSE"],
         cwd=dir,
         env=cmake_env,
         text=True,
@@ -35,11 +35,11 @@ def cmake_verbose(dir, cmake):
 
 # Perform CMake configuration on a dummy application with verbose logging to get the
 # current version number, and then compare this with the version number in settings.yml
-def test_version_match(cmake):
+def test_version_match(cmake, generator):
     app_dir = Path(__file__).parent / "_version_match" / "app_version_match"
 
     cleanup_app(app_dir)
-    output = cmake_verbose(app_dir, cmake)
+    output = cmake_verbose(app_dir, cmake, generator)
 
     version_re = r"^-- XCommon CMake version v([0-9]+\.[0-9]+\.[0-9]+)$"
     match = re.search(version_re, output, flags=re.MULTILINE | re.DOTALL)

--- a/xcommon.cmake
+++ b/xcommon.cmake
@@ -690,10 +690,10 @@ function(XMOS_REGISTER_APP)
             set(PCA_FILE ${DOT_BUILD_DIR}/pca.xml)
             add_custom_command(
                     OUTPUT ${PCA_FILE}
-                    COMMAND $ENV{XMOS_TOOL_PATH}/libexec/xpca ${PCA_FILE} -deps ${DOT_BUILD_DIR}/pca.d ${DOT_BUILD_DIR} "\"${BUILD_ADDED_DEPS_PATHS} \"" @${PCA_FILES_RESP}
+                    COMMAND $ENV{XMOS_TOOL_PATH}/libexec/xpca ${PCA_FILE} -deps ${DOT_BUILD_DIR}/pca.d ${DOT_BUILD_DIR} "${BUILD_ADDED_DEPS_PATHS} " @${PCA_FILES_RESP}
                     DEPENDS ${PCA_FILES_PATH}
-                    DEPFILE ${DOT_BUILD_DIR}/pca.d
-                    COMMAND_EXPAND_LISTS
+                    # DEPFILE ${DOT_BUILD_DIR}/pca.d
+                    VERBATIM
                 )
 
             set(PCA_FLAG "SHELL: -Xcompiler-xc -analysis" "SHELL: -Xcompiler-xc \"${DOT_BUILD_DIR}/pca.xml\"")


### PR DESCRIPTION
only one test needed fixed which was using add_custom_target to generate a file in a way that was not supported by ninja, this was not an issue relating to xcommon cmake so I updated the test to use add_custom_command. This works.