### PR TITLE
Update to xmosdoc version, and prepare for release v1.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 XCommon CMake Change Log
 ========================
 
+UNRELEASED
+----------
+
+  * CHANGED:   xmosdoc v5.5.1 for building documentation
+
 1.2.0
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 XCommon CMake Change Log
 ========================
 
-UNRELEASED
-----------
+1.2.1
+-----
 
   * CHANGED:   xmosdoc v5.5.1 for building documentation
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
     )
     string(
       name: 'XMOSDOC_VERSION',
-      defaultValue: 'v4.0.5',
+      defaultValue: 'v5.5.1',
       description: 'The xmosdoc version'
     )
   }

--- a/doc/quick_start.rst
+++ b/doc/quick_start.rst
@@ -13,8 +13,8 @@ Software Requirements
 Setup
 ^^^^^
 
-.. Note:: XCommon CMake is not yet distributed with the XMOS XTC Tools (correct at version 15.2.1). Once integrated
-   this step can be omitted.
+.. Note:: This step is only required with XMOS XTC Tools prior to 15.3, as XCommon CMake was not
+   distributed with XTC Tools.
 
 Before using XCommon CMake, the environment variable ``XMOS_CMAKE_PATH`` must be set to the location of
 the ``xcommon_cmake`` directory. For example:

--- a/settings.yml
+++ b/settings.yml
@@ -3,6 +3,7 @@ project: xcommon_cmake
 version: 1.2.0
 documentation:
     exclude_patterns_path: doc/exclude_patterns.inc
+    cognidox_part_number: XM-015090-PC
     pdfs:
         index:
             pdf_title: "XCommon CMake"

--- a/settings.yml
+++ b/settings.yml
@@ -1,6 +1,6 @@
 title: XCommon CMake
 project: xcommon_cmake
-version: 1.2.0
+version: 1.2.1
 documentation:
     exclude_patterns_path: doc/exclude_patterns.inc
     cognidox_part_number: XM-015090-PC

--- a/xcommon.cmake
+++ b/xcommon.cmake
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 include_guard(GLOBAL)
 
-set(XCOMMON_CMAKE_VER 1.2.0 CACHE INTERNAL "Version of XCommon CMake")
+set(XCOMMON_CMAKE_VER 1.2.1 CACHE INTERNAL "Version of XCommon CMake")
 
 macro(print_xcommon_cmake_version)
     message(VERBOSE "XCommon CMake version v${XCOMMON_CMAKE_VER}")


### PR DESCRIPTION
- Made a small tweak to the quick start suggested by Tom, so that users receiving this document with XTC 15.3 don't see a line saying "XCommon CMake is not yet distributed with the XMOS XTC Tools" (even though it clarifies that this applies to 15.2.1). I hope my change makes this clearer, but I'm happy to revert this one if it's not good
- Updated xmosdoc version to the latest to get the required directory structure
- Added cognidox part number for the documentation artefacts
- Updated the version number