### PR TITLE
Exit with fatal error if some execute_process() commands fail

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 XCommon CMake Change Log
 ========================
 
+UNRELEASED
+----------
+
+  * FIXED:     execute_process() failures were ignored
+
 1.3.0
 -----
 

--- a/xcommon.cmake
+++ b/xcommon.cmake
@@ -270,7 +270,8 @@ function(parse_dep_string dep_str ret_repo ret_ver ret_name)
             # The Windows NUL didn't work as an input.
             execute_process(COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/ssh-in.tmp
                             OUTPUT_QUIET
-                            ERROR_QUIET)
+                            ERROR_QUIET
+                            COMMAND_ERROR_IS_FATAL ANY)
             set(tmp_input_file ${CMAKE_BINARY_DIR}/ssh-in.tmp)
         else()
             set(tmp_input_file "/dev/null")
@@ -504,7 +505,8 @@ function(XMOS_REGISTER_APP)
         list(GET ALL_SRCS_PATH 0 src0)
         execute_process(COMMAND xcc -dumpmachine ${APP_TARGET_COMPILER_FLAG} ${src0}
                         OUTPUT_VARIABLE APP_BUILD_ARCH
-                        OUTPUT_STRIP_TRAILING_WHITESPACE)
+                        OUTPUT_STRIP_TRAILING_WHITESPACE
+                        COMMAND_ERROR_IS_FATAL ANY)
     else()
         set(APP_BUILD_ARCH "${CMAKE_HOST_SYSTEM_PROCESSOR}")
     endif()


### PR DESCRIPTION
The subprocesses run by `execute_process` that we don't want to fail now have a setting to raise a fatal error if they fail. This was previously missing, so failures of these commands would be ignored and cmake would try to continue. There are some other instances of `execute_process` where failures are correctly handled or can be silently ignored, so those are unchanged.

This was found where an invalid non-filename was set as the APP_HW_TARGET, eg.
```
set(APP_HW_TARGET myboard)
```

xcc doesn't have a target called `myboard` so the architecture check will noisily fail, but cmake generation will continue - a subsequent xmake would fail, but it's clearer to catch the error when it occurs.