### PR TITLE
Add support for libraries specifying linker options for the application in LIB_COMPILER_FLAGS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.swo
 *.swp
 *~
+.DS_Store
 
 # XMOS tmp files
 *.pxa.xml*

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ UNRELEASED
 
   * ADDED:     Troubleshooting section to documentation
   * FIXED:     execute_process() failures were ignored
+  * ADDED:     LIB_LINKER_FLAGS option to libraries for specifying the application's link options
 
 1.3.0
 -----

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ def run_tests(cmake_ver) {
     dir('tests') {
       withTools(params.TOOLS_VERSION) {
         withEnv(["XMOS_CMAKE_PATH=${WORKSPACE}"]) {
-          sh 'pytest -n auto --junitxml=pytest_result.xml'
+          sh 'pytest -n auto --junitxml=pytest_result.xml -v'
         }
       }
     }

--- a/doc/api_reference/variables.rst
+++ b/doc/api_reference/variables.rst
@@ -77,7 +77,7 @@ Optional application variables
   list which provides no compiler options. Example:
 
   .. code-block:: cmake
-  
+
     set(APP_COMPILER_FLAGS_config0 -g -O2 -DMY_DEF=456)
 
 ``APP_COMPILER_FLAGS_<filename>``
@@ -325,6 +325,14 @@ Optional module variables
 
     set(LIB_XSCOPE_SRCS src/config.xscope)
     set(LIB_XSCOPE_SRCS "")
+
+``LIB_LINKER_FLAGS``
+  List of options to the linker to apply when linking applications that depend on this module.
+  These flags are propagated to the application's link options. Example:
+
+  .. code-block:: cmake
+
+    set(LIB_LINKER_FLAGS "-report" "-Wm,--map,test.map")
 
 .. _staticlib-variables:
 

--- a/tests/lib_linker_flags/README.txt
+++ b/tests/lib_linker_flags/README.txt
@@ -1,0 +1,11 @@
+Tests that LIB_LINKER_FLAGS are propagated as target_link_options of the app.
+
+The various libraries that are the app's APP_DEPENDENT_MODULES set various linker options
+through set(LIB_LINKER_FLAGS ...)
+The test compiles the app and checks various things to ensure that the options did get added
+to the app's target_link_options.
+
+The linker options added as -report, -Wm,--map,test_linker_flags.map and -v
+-report is checked by ensuring that the make command stdout has "Constraint check for tile[0]" string.
+-Wm,--map,test_linker_flags.map is checked by checking if the map file test_linker_flags.map exists.
+-v (verbose) is checked by checking if the "xmap --defsymbol" is present in the make stdout

--- a/tests/lib_linker_flags/app_lib_linker_flags/CMakeLists.txt
+++ b/tests/lib_linker_flags/app_lib_linker_flags/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.21)
+include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
+project(lib_linker_flags)
+
+set(APP_HW_TARGET XCORE-AI-EXPLORER)
+set(APP_DEPENDENT_MODULES "lib_mod0" "lib_mod1")
+
+set(XMOS_SANDBOX_DIR "${CMAKE_SOURCE_DIR}/..")
+
+XMOS_REGISTER_APP()

--- a/tests/lib_linker_flags/app_lib_linker_flags/src/app.xc
+++ b/tests/lib_linker_flags/app_lib_linker_flags/src/app.xc
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include "mod0.h"
+#include "mod1.h"
+#include "mod1_1.h"
+
+int main()
+{
+    mod0();
+    mod1();
+    mod1_1();
+    return 0;
+}

--- a/tests/lib_linker_flags/lib_mod0/lib_mod0/api/mod0.h
+++ b/tests/lib_linker_flags/lib_mod0/lib_mod0/api/mod0.h
@@ -1,0 +1,4 @@
+#ifndef MOD0_H
+#define MOD0_H
+void mod0();
+#endif

--- a/tests/lib_linker_flags/lib_mod0/lib_mod0/lib_build_info.cmake
+++ b/tests/lib_linker_flags/lib_mod0/lib_mod0/lib_build_info.cmake
@@ -1,0 +1,7 @@
+set(LIB_NAME lib_mod0)
+set(LIB_VERSION 1.0.0)
+set(LIB_INCLUDES api)
+set(LIB_DEPENDENT_MODULES "")
+set(LIB_LINKER_FLAGS "-Wm,--map,test_linker_flags.map")
+
+XMOS_REGISTER_MODULE()

--- a/tests/lib_linker_flags/lib_mod0/lib_mod0/src/mod0.xc
+++ b/tests/lib_linker_flags/lib_mod0/lib_mod0/src/mod0.xc
@@ -1,0 +1,4 @@
+#include "mod0.h"
+
+void mod0() {}
+

--- a/tests/lib_linker_flags/lib_mod1/lib_mod1/api/mod1.h
+++ b/tests/lib_linker_flags/lib_mod1/lib_mod1/api/mod1.h
@@ -1,0 +1,4 @@
+#ifndef MOD1_H
+#define MOD1_H
+void mod1();
+#endif

--- a/tests/lib_linker_flags/lib_mod1/lib_mod1/lib_build_info.cmake
+++ b/tests/lib_linker_flags/lib_mod1/lib_mod1/lib_build_info.cmake
@@ -1,0 +1,7 @@
+set(LIB_NAME lib_mod1)
+set(LIB_VERSION 1.0.0)
+set(LIB_INCLUDES api)
+set(LIB_DEPENDENT_MODULES "lib_mod1_1")
+set(LIB_LINKER_FLAGS -v)
+
+XMOS_REGISTER_MODULE()

--- a/tests/lib_linker_flags/lib_mod1/lib_mod1/src/mod1.xc
+++ b/tests/lib_linker_flags/lib_mod1/lib_mod1/src/mod1.xc
@@ -1,0 +1,3 @@
+#include "mod1.h"
+
+void mod1() {}

--- a/tests/lib_linker_flags/lib_mod1_1/lib_mod1_1/api/mod1_1.h
+++ b/tests/lib_linker_flags/lib_mod1_1/lib_mod1_1/api/mod1_1.h
@@ -1,0 +1,4 @@
+#ifndef MOD1_1_H
+#define MOD1_1_H
+void mod1_1();
+#endif

--- a/tests/lib_linker_flags/lib_mod1_1/lib_mod1_1/lib_build_info.cmake
+++ b/tests/lib_linker_flags/lib_mod1_1/lib_mod1_1/lib_build_info.cmake
@@ -1,0 +1,7 @@
+set(LIB_NAME lib_mod1)
+set(LIB_VERSION 1.0.0)
+set(LIB_INCLUDES api)
+set(LIB_DEPENDENT_MODULES "")
+set(LIB_LINKER_FLAGS -report)
+
+XMOS_REGISTER_MODULE()

--- a/tests/lib_linker_flags/lib_mod1_1/lib_mod1_1/src/mod1_1.xc
+++ b/tests/lib_linker_flags/lib_mod1_1/lib_mod1_1/src/mod1_1.xc
@@ -1,0 +1,3 @@
+#include "mod1_1.h"
+
+void mod1_1() {}

--- a/tests/test_cmake.py
+++ b/tests/test_cmake.py
@@ -15,9 +15,10 @@ def list_test_dirs():
 
     # Ignore directories that start with these characters
     exclude_start = [".", "_"]
-
+    exclude_full = ["lib_linker_flags"]
     dirs = [d.name for d in base_dir.iterdir() if d.is_dir()]
-    return [d for d in dirs if d[0] not in exclude_start]
+    print(*[d[0] for d in dirs])
+    return [d for d in dirs if d[0] not in exclude_start and d not in exclude_full]
 
 
 def cleanup_static_lib(lib_dir):

--- a/tests/test_lib_linker_flags.py
+++ b/tests/test_lib_linker_flags.py
@@ -1,0 +1,72 @@
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+import yaml
+
+
+def cleanup_app(app_dir):
+    dot_build_dirs = [
+        d.name for d in app_dir.iterdir() if d.is_dir() and d.name.startswith(".build")
+    ]
+    for d in ["build", "bin", *dot_build_dirs]:
+        dir = app_dir / d
+        if dir.exists() and dir.is_dir():
+            shutil.rmtree(dir)
+
+
+def build(dir, cmake):
+    cmake_env = os.environ
+    cmake_env["XMOS_CMAKE_PATH"] = str(Path(__file__).parents[1])
+
+    ret = subprocess.run(
+        [cmake, "-G", "Unix Makefiles", "-B", "build"],
+        cwd=dir,
+        env=cmake_env,
+        text=True, capture_output=True
+    )
+    assert ret.returncode == 0
+
+    ret = subprocess.run(["xmake"], cwd=dir / "build", text=True, stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT)
+    assert ret.returncode == 0
+    return ret.stdout
+
+
+
+# Test that LIB_LINKER_FLAGS are propagated to target_link_options of the app.
+# It build the app and runs various checks to infer if the linker options were applied
+# while linking the app.
+def test_linker_flags(cmake):
+    app_dir = Path(__file__).parent / "lib_linker_flags" / "app_lib_linker_flags"
+
+    cleanup_app(app_dir)
+    output = build(app_dir, cmake)
+
+    failures = []
+
+    # Check that linker option -report option in lib_mod1_1/lib_build_info.cmake gets propagated to the app
+    if "Constraint check for tile[0]:" not in output:
+        failures.append("ERROR: Linker option -report didn't get propagated to the app.")
+
+    # Check that linker option -Wm,--map,test_linker_flags.map in lib_mod0/lib_build_info.cmake gets propagated to the app
+    mapfile = app_dir / "build" / "test_linker_flags.map"
+    if not mapfile.exists():
+        failures.append("ERROR: Linker option -Wm,--map,test_linker_flags.map didn't get propagated to the app")
+
+    # Check that linker option -v in lib_mod1/lib_build_info gets propagated to the app
+    if ("xmap --defsymbol" not in output) and ("xmap.exe --defsymbol" not in output):
+        failures.append("ERROR: Linker option -v didn't get propagated to the app.")
+
+    joined_failures = "\n".join(failures)
+
+    assert len(failures) == 0, (
+        "Errors in test_linker_flags\n"
+        f"{joined_failures}\n\n"
+        "xmake output = \n"
+        f"{output}\n"
+    )
+    # Cleanup
+    cleanup_app(app_dir)

--- a/xcommon.cmake
+++ b/xcommon.cmake
@@ -624,9 +624,14 @@ function(XMOS_REGISTER_APP)
     file(APPEND ${MANIFEST_OUT} "${manifest_str}\n")
 
     set(current_module ${PROJECT_NAME})
+    # List of all LIB_LINKER_FLAGS specified in the various dependent libs.
+    # These will get added to link options of all the target apps in this CMakeLists.txt
+    set_property(GLOBAL PROPERTY APP_LIB_LINKER_FLAGS "")
     XMOS_REGISTER_DEPS("${APP_DEPENDENT_MODULES}")
+    get_property(final_linker_flags GLOBAL PROPERTY ALL_LIB_LINKER_FLAGS)
 
     foreach(target ${APP_BUILD_TARGETS})
+        target_link_options(${target} PRIVATE ${final_linker_flags})
         get_target_property(all_inc_dirs ${target} INCLUDE_DIRECTORIES)
         get_target_property(all_opt_hdrs ${target} OPTIONAL_HEADERS)
         set(opt_hdrs_found "")
@@ -776,7 +781,6 @@ function(XMOS_REGISTER_DEPS DEPS_LIST)
         # Only print if the dependent modules list parameter is non-empty
         message(VERBOSE "Registering dependencies of ${current_module}: ${DEPS_LIST}")
     endif()
-
     foreach(DEP_MODULE ${DEPS_LIST})
         parse_dep_string(${DEP_MODULE} DEP_REPO DEP_VERSION DEP_NAME)
         message(VERBOSE "Dependency: ${DEP_NAME}, repository ${DEP_REPO}, version ${DEP_VERSION}")
@@ -831,6 +835,10 @@ function(XMOS_REGISTER_DEPS DEPS_LIST)
             message(STATUS "Adding dependency ${DEP_NAME}")
             include(${module_dir}/lib_build_info.cmake)
 
+            get_property(current_linker_flags GLOBAL PROPERTY ALL_LIB_LINKER_FLAGS)
+            list(APPEND current_linker_flags ${LIB_LINKER_FLAGS})
+            set_property(GLOBAL PROPERTY ALL_LIB_LINKER_FLAGS "${current_linker_flags}")
+
             manifest_git_status(${DEP_NAME} manifest_str)
 
             # Create the Depends_on column in manifest
@@ -838,7 +846,6 @@ function(XMOS_REGISTER_DEPS DEPS_LIST)
             file(APPEND ${MANIFEST_OUT} "${manifest_str}\n")
         endif()
     endforeach()
-
 endfunction()
 
 # Takes as input the LIB_NAME or archive name from LIB_ARCHIVES, and removes the toolchain's


### PR DESCRIPTION

Note that specifying LIB_COMPILER_FLAGS is only supported for libraries registered as XMOS_REGISTER_MODULE() and not for static libraries that are registered as  XMOS_REGISTER_STATIC_LIB()